### PR TITLE
Catching a mon now rewards all party mon with EXP.

### DIFF
--- a/engine/battle/core.asm
+++ b/engine/battle/core.asm
@@ -323,9 +323,9 @@ StartBattle:
 	jp nc, .checkAnyPartyAlive
 	jr EnemyRan ; if b was greater than the random value, the enemy runs
 
-.outOfSafariBallsText
-	TX_FAR _OutOfSafariBallsText
-	db "@"
+;.outOfSafariBallsText
+	;TX_FAR _OutOfSafariBallsText
+	;db "@"
 
 .playerSendOutFirstMon
 	xor a
@@ -2431,6 +2431,8 @@ UseBagItem:
 	ld [wCapturedMonSpecies], a
 	ld a, $2
 	ld [wBattleResult], a
+	;Gain Experience for captured mon
+	callab GainExperience
 	scf ; set carry
 	ret
 

--- a/engine/battle/experience.asm
+++ b/engine/battle/experience.asm
@@ -2,6 +2,12 @@ GainExperience:
 	ld a, [wLinkState]
 	cp LINK_STATE_BATTLING
 	ret z ; return if link battle
+	
+	;Set all EXP flags to true
+	;TODO: Decide if we should test for BATTLE_TYPE_SAFARI here or not
+	ld a, $ff
+	ld [wPartyGainExpFlags], a
+	
 	call DivideExpDataByNumMonsGainingExp
 	ld hl, wPartyMon1
 	xor a
@@ -19,7 +25,6 @@ GainExperience:
 	predef FlagActionPredef
 	ld a, c
 	and a ; is mon's gain exp flag set?
-	;Todo: Modify exp gain to whole party (remove exp share)
 	pop hl
 	jp z, .nextMon ; if mon's gain exp flag not set, go to next mon
 	ld de, (wPartyMon1HPExp + 1) - (wPartyMon1HP + 1)


### PR DESCRIPTION
Introduces a small bug in that the caught mon can be rewarded EXP for its own capture if it is added to the party.

Closes #6 
Adds #19