### PR TITLE
Flee rate update revision 1

### DIFF
--- a/engine/battle/core.asm
+++ b/engine/battle/core.asm
@@ -304,27 +304,45 @@ StartBattle:
 	ld a, [wEnemyMonSpeed + 1]
 	add a
 	ld b, a ; init b (which is later compared with random value) to (enemy speed % 256) * 2
-	jp c, EnemyRan ; if (enemy speed % 256) > 127, the enemy runs
-	ld a, [wSafariBaitFactor]
-	and a ; is bait factor 0?
-	jr z, .checkEscapeFactor
+	;jp c, EnemyRan ; if (enemy speed % 256) > 127, the enemy runs
+	;ld a, [wSafariBaitFactor]
+	;and a ; is bait factor 0?
+	;jr z, .checkEscapeFactor
 ; bait factor is not 0
 ; divide b by 4 (making the mon less likely to run)
 	;srl b
 	;srl b
 .checkEscapeFactor
+;B is EnemySpeedMod
 	ld a, [wSafariEscapeFactor]
+	ld c, a ;C is escape factor
 	and a ; is escape factor 0?
 	jr z, .compareWithRandomValue
 ; escape factor is not 0
-; multiply b by 2 (making the mon more likely to run)
-	sla b
-	jr nc, .compareWithRandomValue
-; cap b at 255
-	ld b, $ff
+; Add in a portion of the mon's base speed to increase flee rate
+.MultEscapeFact
+	ld hl, wEnemyMonBaseStats
+	inc hl
+	inc hl
+	inc hl
+	ld a, [hl] ;Currently 1/8 base speed per EF but it is increased again if a ball fails so that's 1/4 per turn
+	rra
+	rra
+	rra
+	add b
+	jr c, EnemyRan ;Enemy runs at 255+ flee rate
+	ld b, a ;B is total flee rate
+	dec c ;Decrease counter
+	jr nz, .MultEscapeFact ;keep going until we reach 0
+	jr .compareWithRandomValue
 .compareWithRandomValue
 	call Random
 	cp b
+	
+	;Increase Escape Factor each turn
+	ld hl, wSafariEscapeFactor
+	inc [hl]
+	
 	jp nc, .checkAnyPartyAlive
 	jr EnemyRan ; if b was greater than the random value, the enemy runs
 

--- a/engine/battle/core.asm
+++ b/engine/battle/core.asm
@@ -2460,9 +2460,10 @@ PartyMenuOrRockOrRun:
 	cp BATTLE_TYPE_SAFARI
 	jr nz, .partyMenuWasSelected
 ; safari battle
-	ld a, SAFARI_ROCK
-	ld [wcf91], a
-	jp UseBagItem
+	;ld a, SAFARI_ROCK
+	;ld [wcf91], a
+	;jp UseBagItem
+	jp DisplayBattleMenu
 .partyMenuWasSelected
 	call LoadScreenTilesFromBuffer1
 	xor a ; NORMAL_PARTY_MENU

--- a/engine/battle/core.asm
+++ b/engine/battle/core.asm
@@ -310,8 +310,8 @@ StartBattle:
 	jr z, .checkEscapeFactor
 ; bait factor is not 0
 ; divide b by 4 (making the mon less likely to run)
-	srl b
-	srl b
+	;srl b
+	;srl b
 .checkEscapeFactor
 	ld a, [wSafariEscapeFactor]
 	and a ; is escape factor 0?
@@ -2331,9 +2331,10 @@ DisplayBattleMenu:
 	jr nz, BagWasSelected
 
 ; bait was selected
-	ld a, SAFARI_BAIT
-	ld [wcf91], a
-	jr UseBagItem
+	;ld a, SAFARI_BAIT
+	;ld [wcf91], a
+	;jr UseBagItem
+	jp DisplayBattleMenu
 
 BagWasSelected:
 	call LoadScreenTilesFromBuffer1

--- a/engine/battle/safari_zone.asm
+++ b/engine/battle/safari_zone.asm
@@ -11,7 +11,7 @@ PrintSafariZoneBattleText:
 	ld a, [hl]
 	and a
 	ret z
-	dec [hl]
+	;dec [hl]
 	ld hl, SafariZoneAngryText
 	jr nz, .asm_429f
 	push hl

--- a/engine/items/items.asm
+++ b/engine/items/items.asm
@@ -280,6 +280,11 @@ ItemUseBall:
 	jr .skipShakeCalculations
 
 .failedToCapture
+	;TODO: Make this less garbage
+	;increase escape factor when breaking free from a ball
+	ld hl [wSafariEscapeFactor]
+	inc [hl]
+	
 	ld a, [H_QUOTIENT + 3]
 	ld [wPokeBallCaptureCalcTemp], a ; Save X.
 
@@ -1412,11 +1417,12 @@ VitaminText:
 ItemUseBait:
 	ld hl, ThrewBaitText
 	call PrintText
-	ld hl, wEnemyMonCatchRate ; catch rate
-	srl [hl] ; halve catch rate
+	ret
+	;ld hl, wEnemyMonCatchRate ; catch rate
+	;srl [hl] ; halve catch rate
 	ld a, BAIT_ANIM
 	ld hl, wSafariBaitFactor ; bait factor
-	ld de, wSafariEscapeFactor ; escape factor
+	ld de, wSafariBaitFactor ; DEBUG
 	jr BaitRockCommon
 
 ItemUseRock:
@@ -1451,7 +1457,7 @@ BaitRockCommon:
 	jr nc, .noCarry
 	ld a, $ff
 .noCarry
-	ld [hl], a
+	;ld [hl], a
 	predef MoveAnimation ; do animation
 	ld c, 70
 	jp DelayFrames


### PR DESCRIPTION
Flee rate still draws from the speed of the enemy for now
Each turn it increases by a portion of the base speed
Each time the enemy breaks out of a ball it increases again
This achieves my goal of a tighter timer on battles without diving into the Apprehension features I have planned later

closes #7 