### PR TITLE
Decouple wNumSafariBalls from Great Ball count

### DIFF
--- a/audio/engine_1.asm
+++ b/audio/engine_1.asm
@@ -1330,7 +1330,7 @@ Audio1_PlaySound::
 
 .playMusic
 	xor a
-	ld [wUnusedC000], a
+	;ld [wUnusedC000], a
 	ld [wDisableChannelOutputWhenSfxEnds], a
 	ld [wMusicTempo + 1], a
 	ld [wMusicWaveInstrument], a
@@ -1571,7 +1571,7 @@ Audio1_PlaySound::
 	ld a, $77
 	ld [rNR50], a ; full volume
 	xor a
-	ld [wUnusedC000], a
+	;ld [wUnusedC000], a
 	ld [wDisableChannelOutputWhenSfxEnds], a
 	ld [wMuteAudioAndPauseMusic], a
 	ld [wMusicTempo + 1], a

--- a/audio/engine_2.asm
+++ b/audio/engine_2.asm
@@ -1337,7 +1337,7 @@ Audio2_PlaySound::
 	jp nc, Audio2_2210d
 .asm_2204c
 	xor a
-	ld [wUnusedC000], a
+	;ld [wUnusedC000], a
 	ld [wDisableChannelOutputWhenSfxEnds], a
 	ld [wMusicTempo + 1], a
 	ld [wMusicWaveInstrument], a
@@ -1578,7 +1578,7 @@ Audio2_221f3:
 	ld a, $77
 	ld [rNR50], a
 	xor a
-	ld [wUnusedC000], a
+	;ld [wUnusedC000], a
 	ld [wDisableChannelOutputWhenSfxEnds], a
 	ld [wMuteAudioAndPauseMusic], a
 	ld [wMusicTempo + 1], a

--- a/audio/engine_3.asm
+++ b/audio/engine_3.asm
@@ -1286,7 +1286,7 @@ Audio3_PlaySound::
 	jp nc, Audio3_7d9c2
 .asm_7d901
 	xor a
-	ld [wUnusedC000], a
+	;ld [wUnusedC000], a
 	ld [wDisableChannelOutputWhenSfxEnds], a
 	ld [wMusicTempo + 1], a
 	ld [wMusicWaveInstrument], a
@@ -1527,7 +1527,7 @@ Audio3_7daa8:
 	ld a, $77
 	ld [rNR50], a
 	xor a
-	ld [wUnusedC000], a
+	;ld [wUnusedC000], a
 	ld [wDisableChannelOutputWhenSfxEnds], a
 	ld [wMuteAudioAndPauseMusic], a
 	ld [wMusicTempo + 1], a

--- a/constants/misc_constants.asm
+++ b/constants/misc_constants.asm
@@ -74,6 +74,7 @@ TWO_OPTION_MENU                   EQU $14
 BUY_SELL_QUIT_MENU                EQU $15
 JP_POKEDEX_MENU_TEMPLATE          EQU $1a
 SAFARI_BATTLE_MENU_TEMPLATE       EQU $1b
+SAFARI_BATTLE_MENU_TEMPLATE_PG2   EQU $1c
 
 ; two option menu constants
 YES_NO_MENU       EQU 0

--- a/engine/cable_club.asm
+++ b/engine/cable_club.asm
@@ -836,7 +836,7 @@ TradeCenter_Trade:
 	call ClearScreen
 	call LoadHpBarAndStatusTilePatterns
 	xor a
-	ld [wUnusedCC5B], a
+	;ld [wUnusedCC5B], a
 	ld a, [hSerialConnectionStatus]
 	cp USING_EXTERNAL_CLOCK
 	jr z, .usingExternalClock

--- a/engine/hidden_object_functions7.asm
+++ b/engine/hidden_object_functions7.asm
@@ -37,11 +37,11 @@ StrengthsAndWeaknessesText:
 	db "@"
 
 SafariZoneCheck:
-	CheckEventHL EVENT_IN_SAFARI_ZONE ; if we are not in the Safari Zone,
-	jr z, SafariZoneGameStillGoing ; don't bother printing game over text
-	ld a, [wNumSafariBalls]
-	and a
-	jr z, SafariZoneGameOver
+	;CheckEventHL EVENT_IN_SAFARI_ZONE ; if we are not in the Safari Zone,
+	;jr z, SafariZoneGameStillGoing ; don't bother printing game over text
+	;ld a, [wNumSafariBalls]
+	;and a
+	;jr z, SafariZoneGameOver
 	jr SafariZoneGameStillGoing
 
 SafariZoneCheckSteps:
@@ -98,13 +98,10 @@ PrintSafariGameOverText:
 
 SafariGameOverText:
 	TX_ASM
-	ld a, [wNumSafariBalls]
-	and a
-	jr z, .noMoreSafariBalls
+	;ld a, [wNumSafariBalls]
+	;and a
+	;jr z, .noMoreSafariBalls
 	ld hl, TimesUpText
-	call PrintText
-.noMoreSafariBalls
-	ld hl, GameOverText
 	call PrintText
 	jp TextScriptEnd
 

--- a/engine/items/items.asm
+++ b/engine/items/items.asm
@@ -132,8 +132,8 @@ ItemUseBall:
 	jr nz, .skipSafariZoneCode
 
 .safariZone
-	ld hl, wNumSafariBalls
-	dec [hl] ; remove a Safari Ball
+	;ld hl, wNumSafariBalls
+	;dec [hl] ; remove a Safari Ball
 
 .skipSafariZoneCode
 	call RunDefaultPaletteCommand
@@ -1494,7 +1494,7 @@ ItemUseEscapeRope:
 	res 4, [hl]
 	ResetEvent EVENT_IN_SAFARI_ZONE
 	xor a
-	ld [wNumSafariBalls], a
+	;ld [wNumSafariBalls], a
 	ld [wSafariZoneEntranceCurScript], a
 	inc a
 	ld [wEscapedFromBattle], a

--- a/engine/menu/main_menu.asm
+++ b/engine/menu/main_menu.asm
@@ -150,7 +150,7 @@ LinkMenu:
 	ld de, CableClubOptionsText
 	call PlaceString
 	xor a
-	ld [wUnusedCD37], a
+	;ld [wUnusedCD37], a
 	ld [wd72d], a
 	ld hl, wTopMenuItemY
 	ld a, $7

--- a/engine/menu/text_box.asm
+++ b/engine/menu/text_box.asm
@@ -189,6 +189,11 @@ TextBoxTextAndCoordTable:
 	db 0,12,19,17  ; text box coordinates
 	dw SafariZoneBattleMenuText
 	db 2,14  ; text coordinates
+	
+	db SAFARI_BATTLE_MENU_TEMPLATE_PG2
+	db 0,12,19,17  ; text box coordinates
+	dw SafariZoneBattleMenuText_PG2
+	db 2,14  ; text coordinates
 
 	db SWITCH_STATS_CANCEL_MENU_TEMPLATE
 	db 11,11,19,17 ; text box coordinates
@@ -249,8 +254,12 @@ BattleMenuText:
 	next "ITEM  RUN@"
 
 SafariZoneBattleMenuText:
-	db   "BALL×       BAIT"
-	next "THROW ROCK  RUN@"
+	db   "BALL×       PAGE"
+	next "BERRY×      RUN@"
+	
+SafariZoneBattleMenuText_PG2:
+	db   "NONE        PAGE"
+	next "NONE        NONE@"
 
 SwitchStatsCancelText:
 	db   "SWITCH"

--- a/engine/overworld/player_state.asm
+++ b/engine/overworld/player_state.asm
@@ -251,25 +251,25 @@ PrintSafariZoneSteps:
 	ld de, SafariSteps
 	call PlaceString
 	coord hl, 1, 3
-	ld de, SafariBallText
-	call PlaceString
-	ld a, [wNumSafariBalls]
-	cp 10
-	jr nc, .asm_c56d
-	coord hl, 5, 3
-	ld a, " "
-	ld [hl], a
+	;ld de, SafariBallText
+	;call PlaceString
+	;ld a, [wNumSafariBalls]
+	;cp 10
+	;jr nc, .asm_c56d
+	;coord hl, 5, 3
+	;ld a, " "
+	;ld [hl], a
 .asm_c56d
-	coord hl, 6, 3
-	ld de, wNumSafariBalls
-	lb bc, 1, 2
-	jp PrintNumber
+	;coord hl, 6, 3
+	;ld de, wNumSafariBalls
+	;lb bc, 1, 2
+	;jp PrintNumber
 
 SafariSteps:
 	db "/500@"
 
 SafariBallText:
-	db "BALL×× @"
+	db "@"
 
 GetTileAndCoordsInFrontOfPlayer:
 	call GetPredefRegisters

--- a/engine/titlescreen.asm
+++ b/engine/titlescreen.asm
@@ -215,7 +215,7 @@ ENDC
 	ld [wNewSoundID], a
 	call PlaySound
 	xor a
-	ld [wUnusedCC5B], a
+	;ld [wUnusedCC5B], a
 
 ; Keep scrolling in new mons indefinitely until the user performs input.
 .awaitUserInterruptionLoop

--- a/scripts/safarizoneentrance.asm
+++ b/scripts/safarizoneentrance.asm
@@ -84,7 +84,7 @@ SafariZoneEntranceScriptPointers:
 	ld [hSpriteIndexOrTextID], a
 	call DisplayTextID
 	xor a
-	ld [wNumSafariBalls], a
+	;ld [wNumSafariBalls], a
 	ld a, D_DOWN
 	ld c, $3
 	call SafariZoneEntranceAutoWalk
@@ -180,8 +180,8 @@ SafariZoneEntranceTextPointers:
 	call DisplayTextBoxID
 	ld hl, .MakePaymentText
 	call PrintText
-	ld a, 30
-	ld [wNumSafariBalls], a
+	;ld a, 30
+	;ld [wNumSafariBalls], a
 	ld a, 502 / $100
 	ld [wSafariSteps], a
 	ld a, 502 % $100

--- a/wram.asm
+++ b/wram.asm
@@ -824,8 +824,6 @@ wInGameTradeReceiveMonSpecies::
 
 wNPCMovementDirections2Index:: ; cd37
 
-wSafariModePage:: ; cd37
-
 wFilteredBagItemsCount:: ; cd37
 ; number of items in wFilteredBagItems list
 	ds 1
@@ -3227,6 +3225,9 @@ wBoxMonNicks:: ds NAME_LENGTH * MONS_PER_BOX ; de06
 wBoxMonNicksEnd:: ; dee2
 
 wBoxDataEnd::
+
+wSafariModePage:: ; dee3
+	ds 1
 
 
 SECTION "Stack", WRAMX[$df00], BANK[1]

--- a/wram.asm
+++ b/wram.asm
@@ -62,7 +62,7 @@ ENDM
 
 SECTION "WRAM Bank 0", WRAM0
 
-wUnusedC000:: ; c000
+wItemCount1:: ; c000
 	ds 1
 
 wSoundID:: ; c001
@@ -542,7 +542,7 @@ wNPCMovementScriptBank:: ; cc58
 
 	ds 2
 
-wUnusedCC5B:: ; cc5b
+wItemCount2:: ; cc5b
 
 wVermilionDockTileMapBuffer:: ; cc5b
 ; 180 bytes
@@ -824,7 +824,7 @@ wInGameTradeReceiveMonSpecies::
 
 wNPCMovementDirections2Index:: ; cd37
 
-wUnusedCD37:: ; cd37
+wSafariModePage:: ; cd37
 
 wFilteredBagItemsCount:: ; cd37
 ; number of items in wFilteredBagItems list
@@ -3196,7 +3196,7 @@ wPlayTimeFrames:: ; da45
 wSafariZoneGameOver:: ; da46
 	ds 1
 
-wNumSafariBalls:: ; da47
+wUnusedWRAMda74:: ; da47
 	ds 1
 
 


### PR DESCRIPTION
This paves the way for having more throwables listed (up to 2 per page)
We also now have an extra byte of SRAM thanks to holding item and page data outside of SRAM