### PR TITLE
Gen 1 Bugfixes Part 2

### DIFF
--- a/data/baseStats/eevee.asm
+++ b/data/baseStats/eevee.asm
@@ -13,7 +13,7 @@ dw EeveePicFront
 dw EeveePicBack
 ; attacks known at lvl 0
 db TACKLE
-db SAND_ATTACK
+db TAIL_WHIP
 db 0
 db 0
 db 0 ; growth rate

--- a/data/evos_moves.asm
+++ b/data/evos_moves.asm
@@ -1347,10 +1347,9 @@ Mon133_EvosMoves:
 	db 0
 Mon133_EvosEnd:
 ;Learnset
-	db 27,QUICK_ATTACK
-	db 31,TAIL_WHIP
-	db 37,BITE
-	db 45,TAKE_DOWN
+	db 12,QUICK_ATTACK
+	db 20,BITE
+	db 28,TAKE_DOWN
 	db 0
 
 Mon136_EvosMoves:
@@ -1358,9 +1357,8 @@ Mon136_EvosMoves:
 ;Evolutions
 	db 0
 ;Learnset
-	db 27,QUICK_ATTACK
+	db 12,QUICK_ATTACK
 	db 31,EMBER
-	db 37,TAIL_WHIP
 	db 40,BITE
 	db 42,LEER
 	db 44,FIRE_SPIN
@@ -1373,9 +1371,8 @@ Mon135_EvosMoves:
 ;Evolutions
 	db 0
 ;Learnset
-	db 27,QUICK_ATTACK
+	db 12,QUICK_ATTACK
 	db 31,THUNDERSHOCK
-	db 37,TAIL_WHIP
 	db 40,THUNDER_WAVE
 	db 42,DOUBLE_KICK
 	db 44,AGILITY
@@ -1388,9 +1385,8 @@ Mon134_EvosMoves:
 ;Evolutions
 	db 0
 ;Learnset
-	db 27,QUICK_ATTACK
+	db 12,QUICK_ATTACK
 	db 31,WATER_GUN
-	db 37,TAIL_WHIP
 	db 40,BITE
 	db 42,ACID_ARMOR
 	db 44,HAZE

--- a/data/hidden_objects.asm
+++ b/data/hidden_objects.asm
@@ -456,9 +456,9 @@ GameCornerHiddenObjects:
 	dbw BANK(HiddenCoins),HiddenCoins
 	db $FF
 CeladonHotelHiddenObjects:
-	db $03,$0d,$04
-	db BANK(OpenPokemonCenterPC)
-	dw OpenPokemonCenterPC
+	;db $03,$0d,$04
+	;db BANK(OpenPokemonCenterPC)
+	;dw OpenPokemonCenterPC
 	db $04,$00,$08
 	db Bank(PrintBenchGuyText)
 	dw PrintBenchGuyText

--- a/data/trainer_parties.asm
+++ b/data/trainer_parties.asm
@@ -452,9 +452,7 @@ BlackbeltData:
 	db 43,MACHOKE,MACHOP,MACHOKE,0
 Green1Data:
 ;Oaks Lab
-	;Eventually Green will choose an Eeveelution and stick with it the whole game.
-	;Or if he has Pikachu his other mons can vary? I dunno
-	;For now he'll always pick the same team. TODO: randomize which team green picks at the start of the game.
+	;Green will choose an Eeveelution and stick with it the whole game.
 	IF DEF(_RED)
 	db 5, PIKACHU, 0
 	db 5, PIKACHU, 0

--- a/engine/battle/core.asm
+++ b/engine/battle/core.asm
@@ -7920,12 +7920,12 @@ StatModifierDownEffect:
 	ld hl, wPlayerMonStatMods
 	ld de, wEnemyMoveEffect
 	ld bc, wPlayerBattleStatus1
-	ld a, [wLinkState]
-	cp LINK_STATE_BATTLING
-	jr z, .statModifierDownEffect
-	call BattleRandom
-	cp $40 ; 1/4 chance to miss by in regular battle
-	jp c, MoveMissed
+	;ld a, [wLinkState]
+	;cp LINK_STATE_BATTLING
+	;jr z, .statModifierDownEffect
+	;call BattleRandom
+	;cp $40 ; 1/4 chance to miss by in regular battle
+	;jp c, MoveMissed
 .statModifierDownEffect
 	call CheckTargetSubstitute ; can't hit through substitute
 	jp nz, MoveMissed

--- a/engine/battle/core.asm
+++ b/engine/battle/core.asm
@@ -7402,10 +7402,8 @@ SleepEffect:
 	ld bc, wPlayerBattleStatus2
 
 .sleepEffect
-	ld a, [bc]
-	bit NEEDS_TO_RECHARGE, a ; does the target need to recharge? (hyper beam)
-	res NEEDS_TO_RECHARGE, a ; target no longer needs to recharge
-	ld [bc], a
+	;Store pointer to Status2
+	push bc
 	jr nz, .setSleepCounter ; if the target had to recharge, all hit tests will be skipped
 	                        ; including the event where the target already has another status
 	ld a, [de]
@@ -7431,6 +7429,12 @@ SleepEffect:
 	jr z, .setSleepCounter
 	ld [de], a
 	call PlayCurrentMoveAnimation2
+	;Recall pointer to Status2
+	pop bc
+	;Reset recharge bit
+	ld a, [bc]
+	res NEEDS_TO_RECHARGE, a
+	ld [bc], a
 	ld hl, FellAsleepText
 	jp PrintText
 .didntAffect

--- a/engine/items/items.asm
+++ b/engine/items/items.asm
@@ -1432,10 +1432,10 @@ ItemUseBerry:
 	ld [wSafariBaitFactor], a
 	ld hl, wSafariEscapeFactor ; escape factor reduction
 	dec [hl]
+	ld hl, ThrewBerryText
 	jr nc, .Animation
 	ld a, 0
 	ld [wSafariEscapeFactor], a
-	ld hl, ThrewBerryText
 .Animation
 	call PrintText
 	ld a, BAIT_ANIM

--- a/engine/items/items.asm
+++ b/engine/items/items.asm
@@ -1431,7 +1431,11 @@ ItemUseBerry:
 	ld a, 3 ;Eating text for 3 turns
 	ld [wSafariBaitFactor], a
 	ld hl, wSafariEscapeFactor ; escape factor reduction
+	ld a, [hl]
+	cp 0
+	jr z, .NoDec ;skip it if it would underflow
 	dec [hl]
+.NoDec
 	ld hl, ThrewBerryText
 	jr nc, .Animation
 	ld a, 0


### PR DESCRIPTION
- [x] Removes invisible PC from Celadon Hotel
- [x] Fixes mons that are recharging are 100% vulnerable to sleep even when statused
- [x] Fixes mons that are paralyzed while using fly/dig stay invulnerable (player only)
- [x] Removes handicap from AI status dropping moves
- [ ] Fixes reordering moves while transformed breaks things
- [ ] Fixes bide bad behavior under some circumstances